### PR TITLE
set source-file encoding fro python2

### DIFF
--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 import FreeCAD
 from FreeCAD import Vector


### PR DESCRIPTION
Setting source file encoding in CurvedShapes.py to prevent error with freecad build with python2.

see: https://www.python.org/dev/peps/pep-0263/