### PR TITLE
Bug fix - variable sumbbox is not defined

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -145,6 +145,7 @@ class CurvedArrayWorker:
         
         self.doScaleXYZ = []
         self.doScaleXYZsum = [False, False, False]
+        sumbbox=None   #Define the variable other wise it causes error 
         for h in prop.Hullcurves:
             bbox = h.Shape.BoundBox
             if h == prop.Hullcurves[0]:


### PR DESCRIPTION
You need to define the variable before using it otherwise Freecad generates an error.