### PR TITLE
Fix __getstate__/__setstate__ methods for FreeCAD >= 0.22

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -228,12 +228,20 @@ class CurvedArrayViewProvider:
     
     def onChanged(self, fp, prop):
         pass
-        
-    def __getstate__(self):
-        return None
- 
-    def __setstate__(self,state):
-        return None
+
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self,state):
+            return None
         
 
 class CurvedArray():

--- a/CurvedPathArray.py
+++ b/CurvedPathArray.py
@@ -209,11 +209,20 @@ class CurvedPathArrayViewProvider:
     def onChanged(self, fp, prop):
         pass
         
-    def __getstate__(self):
-        return None
- 
-    def __setstate__(self,state):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self,state):
+            return None
+
         
 
 class CurvedPathArray():

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -419,11 +419,19 @@ class CurvedSegmentViewProvider:
     def onChanged(self, fp, prop):
         pass
         
-    def __getstate__(self):
-        return None
- 
-    def __setstate__(self,state):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self,state):
+            return None
         
 
 class CurvedSegment():

--- a/InterpolatedMiddle.py
+++ b/InterpolatedMiddle.py
@@ -153,11 +153,19 @@ class InterpolatedMiddleViewProvider:
     def onChanged(self, fp, prop):
         pass
         
-    def __getstate__(self):
-        return None
- 
-    def __setstate__(self,state):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self,state):
+            return None
         
 
 class InterpolatedMiddle():

--- a/NotchConnector.py
+++ b/NotchConnector.py
@@ -189,11 +189,19 @@ class NotchConnectorViewProvider:
     def onChanged(self, fp, prop):
         pass
         
-    def __getstate__(self):
-        return None
- 
-    def __setstate__(self,state):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def loads(self, state):
+            return None
+
+        def dumps(self):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self,state):
+            return None
         
 
 class NotchConnector():


### PR DESCRIPTION
As of https://github.com/FreeCAD/FreeCAD/commit/83d4080fe8 FreeCAD (for compatibility with Python 3.11) has renamed the methods to loads and dumps. Using this workbench with the latest FreeCAD main branch surfaced this issue as I wasn't able to save my documents again.

I found the change
https://github.com/fra589/CurvesWB/commit/3374dbb83ea2a09787819b1e153a5697f5e19ea7 in the CurvesWB and adopted it for this WB.

Since others might run into the issue with an eager need to save the document, this is how I temporary fixed the issue via the Python console from within FreeCAD:

> import CurvedShapes.CurvedArray
> CurvedArray.CurvedArrayViewProvider.loads = lambda self, state: None
> CurvedArray.CurvedArrayViewProvider.dumps = lambda self: None

(Adjust to match whatever object you have in your document)