### PR TITLE
Fix CurvedSegment edge case when bsplines have different num of poles

### DIFF
--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -115,8 +115,8 @@ class CurvedSegmentWorker:
             for e in range(0, len(fp.Shape1.Shape.Edges)):
                 edge1 = fp.Shape1.Shape.Edges[e]
                 edge2 = fp.Shape2.Shape.Edges[e]
-                curve1 = edge1.Curve.toBSpline()
-                curve2 = edge2.Curve.toBSpline()
+                curve1 = edge1.Curve.toBSpline(edge1.FirstParameter, edge1.LastParameter)
+                curve2 = edge2.Curve.toBSpline(edge2.FirstParameter, edge2.LastParameter)
                 poles1 = curve1.getPoles()
                 poles2 = curve2.getPoles()
                 if len(poles1) != len(poles2):


### PR DESCRIPTION
In one of my recent FreeCAD adventures I tried to create a curved segment between a sketch, a downscaled version of the sketch and a simple hullcurve. The CurvedShapeWB would always fail with an IndexError from within the `makeRibsSameShape` function. This was caused by a mismatch in poles between the two shapes. Something that should have been caught by the code in CurvedSegmentWorker::makeRibs.

It turned out that the actual code for the (non-interpolated) ribs passed the `FirstParameter` and `LastParameter` to the `toBSpline` function which the check in the Worker class didn't. Passing those parameters to the checking code ensured that my curve ended up in the interpolation code path and thus stopped throwing exceptions and produced the correct objects in FreeCAD.