### PR TITLE
Make maxDegree of internally generated lofts configurable (Issue #36)

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -32,7 +32,6 @@ class CurvedArrayWorker:
                  extract=False,
                  Twists = [],
                  LoftMaxDegree=5):
-        obj.Base = base
         CurvedShapes.addObjectProperty(obj, "App::PropertyLink",  "Base",     "CurvedArray",   "The object to make an array from").Base = base
         CurvedShapes.addObjectProperty(obj, "App::PropertyLinkList",  "Hullcurves",   "CurvedArray",   "Bounding curves").Hullcurves = hullcurves        
         CurvedShapes.addObjectProperty(obj, "App::PropertyVector", "Axis",    "CurvedArray",   "Direction axis").Axis = axis

--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -30,27 +30,29 @@ class CurvedArrayWorker:
                  Distribution = 'linear',
                  DistributionReverse = False,
                  extract=False,
-                 Twists = []):
-        obj.addProperty("App::PropertyLink",  "Base",     "CurvedArray",   "The object to make an array from").Base = base
-        obj.addProperty("App::PropertyLinkList",  "Hullcurves",   "CurvedArray",   "Bounding curves").Hullcurves = hullcurves        
-        obj.addProperty("App::PropertyVector", "Axis",    "CurvedArray",   "Direction axis").Axis = axis
-        obj.addProperty("App::PropertyQuantity", "Items", "CurvedArray",   "Nr. of array items").Items = items
-        obj.addProperty("App::PropertyFloatList","Positions", "CurvedArray","Positions for ribs (as floats from 0.0 to 1.0) -- overrides Items").Positions = Positions
-        obj.addProperty("App::PropertyFloat", "OffsetStart","CurvedArray",  "Offset of the first part in Axis direction").OffsetStart = OffsetStart
-        obj.addProperty("App::PropertyFloat", "OffsetEnd","CurvedArray",  "Offset of the last part from the end in opposite Axis direction").OffsetEnd = OffsetEnd
-        obj.addProperty("App::PropertyFloat", "Twist","CurvedArray",  "Rotate around Axis in degrees").Twist = Twist
-        obj.addProperty("App::PropertyFloatList","Twists", "CurvedArray","Rotate around Axis in degrees for each item -- overrides Twist").Twists = Twists
-        obj.addProperty("App::PropertyBool", "Surface","CurvedArray",  "Make a surface").Surface = Surface
-        obj.addProperty("App::PropertyBool", "Solid","CurvedArray",  "Make a solid").Solid = Solid
-        obj.addProperty("App::PropertyEnumeration", "Distribution", "CurvedArray",  "Algorithm for distance between elements")
-        obj.addProperty("App::PropertyBool", "DistributionReverse", "CurvedArray",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
+                 Twists = [],
+                 LoftMaxDegree=5):
+        obj.Base = base
+        CurvedShapes.addObjectProperty(obj, "App::PropertyLink",  "Base",     "CurvedArray",   "The object to make an array from").Base = base
+        CurvedShapes.addObjectProperty(obj, "App::PropertyLinkList",  "Hullcurves",   "CurvedArray",   "Bounding curves").Hullcurves = hullcurves        
+        CurvedShapes.addObjectProperty(obj, "App::PropertyVector", "Axis",    "CurvedArray",   "Direction axis").Axis = axis
+        CurvedShapes.addObjectProperty(obj, "App::PropertyQuantity", "Items", "CurvedArray",   "Nr. of array items").Items = items
+        CurvedShapes.addObjectProperty(obj, "App::PropertyFloatList","Positions", "CurvedArray","Positions for ribs (as floats from 0.0 to 1.0) -- overrides Items").Positions = Positions
+        CurvedShapes.addObjectProperty(obj, "App::PropertyFloat", "OffsetStart","CurvedArray",  "Offset of the first part in Axis direction").OffsetStart = OffsetStart
+        CurvedShapes.addObjectProperty(obj, "App::PropertyFloat", "OffsetEnd","CurvedArray",  "Offset of the last part from the end in opposite Axis direction").OffsetEnd = OffsetEnd
+        CurvedShapes.addObjectProperty(obj, "App::PropertyFloat", "Twist","CurvedArray",  "Rotate around Axis in degrees").Twist = Twist
+        CurvedShapes.addObjectProperty(obj, "App::PropertyFloatList","Twists", "CurvedArray","Rotate around Axis in degrees for each item -- overrides Twist").Twists = Twists
+        CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "Surface","CurvedArray",  "Make a surface").Surface = Surface
+        CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "Solid","CurvedArray",  "Make a solid").Solid = Solid
+        CurvedShapes.addObjectProperty(obj, "App::PropertyEnumeration", "Distribution", "CurvedArray",  "Algorithm for distance between elements")
+        CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "DistributionReverse", "CurvedArray",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
+        CurvedShapes.addObjectProperty(obj, "App::PropertyInteger", "LoftMaxDegree", "CurvedArray",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
         obj.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         obj.Distribution = Distribution
         self.extract = extract
         self.doScaleXYZ = []
         self.doScaleXYZsum = [False, False, False]
         obj.Proxy = self
-       
 
     def makeRibs(self, obj):
         pl = obj.Placement
@@ -111,7 +113,7 @@ class CurvedArrayWorker:
 
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
-            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid)
+            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree)
         else:
             obj.Shape = Part.makeCompound(ribs)
             
@@ -193,6 +195,7 @@ class CurvedArrayWorker:
         for p in proplist:
             if not hasattr(fp, p):
                 return
+        CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedArray",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
 
         if prop in proplist:                
             if "Positions" in prop and len(fp.Positions) != 0:

--- a/CurvedPathArray.py
+++ b/CurvedPathArray.py
@@ -28,19 +28,21 @@ class CurvedPathArrayWorker:
                  Surface=True, 
                  Solid = False,
                  doScale = [],
-                 extract=False):
-        obj.addProperty("App::PropertyLink",  "Base",     "CurvedPathArray",   "The object to make an array from").Base = base
-        obj.addProperty("App::PropertyLink",  "Path",     "CurvedPathArray",   "Sweep path").Path = path
-        obj.addProperty("App::PropertyLinkList",  "Hullcurves",   "CurvedPathArray",   "Bounding curves").Hullcurves = hullcurves   
-        obj.addProperty("App::PropertyQuantity", "Items", "CurvedPathArray",   "Nr. of array items").Items = items
-        obj.addProperty("App::PropertyFloat", "OffsetStart","CurvedPathArray",  "Offset of the first part").OffsetStart = OffsetStart
-        obj.addProperty("App::PropertyFloat", "OffsetEnd","CurvedPathArray",  "Offset of the last part from the end in opposite direction").OffsetEnd = OffsetEnd
-        obj.addProperty("App::PropertyFloat", "Twist","CurvedPathArray",  "Rotate in degrees around the sweep path").Twist = Twist
-        obj.addProperty("App::PropertyBool", "Surface","CurvedPathArray",  "Make a surface").Surface = Surface
-        obj.addProperty("App::PropertyBool", "Solid","CurvedPathArray",  "Make a solid").Solid = Solid
-        obj.addProperty("App::PropertyBool", "ScaleX","CurvedPathArray",  "Scale by hullcurves in X direction").ScaleX = True
-        obj.addProperty("App::PropertyBool", "ScaleY","CurvedPathArray",  "Scale by hullcurves in Y direction").ScaleY = True
-        obj.addProperty("App::PropertyBool", "ScaleZ","CurvedPathArray",  "Scale by hullcurves in Z direction").ScaleZ = True
+                 extract=False,
+                 LoftMaxDegree=5):
+        CurvedShapes.addObjectProperty(obj,"App::PropertyLink",  "Base",     "CurvedPathArray",   "The object to make an array from").Base = base
+        CurvedShapes.addObjectProperty(obj,"App::PropertyLink",  "Path",     "CurvedPathArray",   "Sweep path").Path = path
+        CurvedShapes.addObjectProperty(obj,"App::PropertyLinkList",  "Hullcurves",   "CurvedPathArray",   "Bounding curves").Hullcurves = hullcurves   
+        CurvedShapes.addObjectProperty(obj,"App::PropertyQuantity", "Items", "CurvedPathArray",   "Nr. of array items").Items = items
+        CurvedShapes.addObjectProperty(obj,"App::PropertyFloat", "OffsetStart","CurvedPathArray",  "Offset of the first part").OffsetStart = OffsetStart
+        CurvedShapes.addObjectProperty(obj,"App::PropertyFloat", "OffsetEnd","CurvedPathArray",  "Offset of the last part from the end in opposite direction").OffsetEnd = OffsetEnd
+        CurvedShapes.addObjectProperty(obj,"App::PropertyFloat", "Twist","CurvedPathArray",  "Rotate in degrees around the sweep path").Twist = Twist
+        CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "Surface","CurvedPathArray",  "Make a surface").Surface = Surface
+        CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "Solid","CurvedPathArray",  "Make a solid").Solid = Solid
+        CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleX","CurvedPathArray",  "Scale by hullcurves in X direction").ScaleX = True
+        CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleY","CurvedPathArray",  "Scale by hullcurves in Y direction").ScaleY = True
+        CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleZ","CurvedPathArray",  "Scale by hullcurves in Z direction").ScaleZ = True
+        CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "LoftMaxDegree", "CurvedPathArray",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
         self.doScaleXYZsum = [False, False, False]
         if len(doScale) == 3:
             obj.ScaleX = doScale[0]
@@ -131,7 +133,7 @@ class CurvedPathArrayWorker:
         
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
-            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid)
+            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree)
         else:
             obj.Shape = Part.makeCompound(ribs)
             
@@ -183,6 +185,7 @@ class CurvedPathArrayWorker:
         for p in proplist:
             if not hasattr(fp, p):
                 return 
+        CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "LoftMaxDegree", "CurvedPathArray",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
             
         if prop in proplist:      
             self.execute(fp)

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -30,20 +30,22 @@ class CurvedSegmentWorker:
                  Twist = 0.0,
                  TwistReverse = False,
                  Distribution = 'linear',
-                 DistributionReverse = False):
-        fp.addProperty("App::PropertyLink",  "Shape1",     "CurvedSegment",   "The first object of the segment").Shape1 = shape1
-        fp.addProperty("App::PropertyLink",  "Shape2",     "CurvedSegment",   "The last object of the segment").Shape2 = shape2
-        fp.addProperty("App::PropertyLinkList",  "Hullcurves",   "CurvedSegment",   "Bounding curves").Hullcurves = hullcurves        
-        fp.addProperty("App::PropertyVector", "NormalShape1",    "CurvedSegment",   "Direction axis of Shape1").NormalShape1 = normalShape1 
-        fp.addProperty("App::PropertyVector", "NormalShape2",    "CurvedSegment",   "Direction axis of Shape2").NormalShape1 = normalShape2
-        fp.addProperty("App::PropertyInteger", "Items", "CurvedSegment",   "Nr. of items between the segments").Items = items
-        fp.addProperty("App::PropertyBool", "makeSurface","CurvedSegment",  "Make a surface").makeSurface = surface
-        fp.addProperty("App::PropertyBool", "makeSolid","CurvedSegment",  "Make a solid").makeSolid = solid
-        fp.addProperty("App::PropertyInteger", "InterpolationPoints", "CurvedSegment",   "Unequal edges will be split into this number of points").InterpolationPoints = InterpolationPoints
-        fp.addProperty("App::PropertyFloat", "Twist","CurvedSegment",  "Compensates a rotation between Shape1 and Shape2").Twist = Twist
-        fp.addProperty("App::PropertyBool", "TwistReverse","CurvedSegment",  "Reverses the rotation of one Shape").TwistReverse = TwistReverse
-        fp.addProperty("App::PropertyEnumeration", "Distribution", "CurvedSegment",  "Algorithm for distance between elements")
-        fp.addProperty("App::PropertyBool", "DistributionReverse", "CurvedSegment",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
+                 DistributionReverse = False,
+                 LoftMaxDegree=5):
+        CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "CurvedSegment",   "The first object of the segment").Shape1 = shape1
+        CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "CurvedSegment",   "The last object of the segment").Shape2 = shape2
+        CurvedShapes.addObjectProperty(fp,"App::PropertyLinkList",  "Hullcurves",   "CurvedSegment",   "Bounding curves").Hullcurves = hullcurves        
+        CurvedShapes.addObjectProperty(fp,"App::PropertyVector", "NormalShape1",    "CurvedSegment",   "Direction axis of Shape1").NormalShape1 = normalShape1 
+        CurvedShapes.addObjectProperty(fp,"App::PropertyVector", "NormalShape2",    "CurvedSegment",   "Direction axis of Shape2").NormalShape1 = normalShape2
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "Items", "CurvedSegment",   "Nr. of items between the segments").Items = items
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "makeSurface","CurvedSegment",  "Make a surface").makeSurface = surface
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "makeSolid","CurvedSegment",  "Make a solid").makeSolid = solid
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "InterpolationPoints", "CurvedSegment",   "Unequal edges will be split into this number of points").InterpolationPoints = InterpolationPoints
+        CurvedShapes.addObjectProperty(fp,"App::PropertyFloat", "Twist","CurvedSegment",  "Compensates a rotation between Shape1 and Shape2").Twist = Twist
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "TwistReverse","CurvedSegment",  "Reverses the rotation of one Shape").TwistReverse = TwistReverse
+        CurvedShapes.addObjectProperty(fp,"App::PropertyEnumeration", "Distribution", "CurvedSegment",  "Algorithm for distance between elements")
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "DistributionReverse", "CurvedSegment",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "CurvedSegment",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
         fp.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         fp.Distribution = Distribution
         self.doScaleXYZ = []
@@ -103,6 +105,7 @@ class CurvedSegmentWorker:
         for p in proplist:
             if not hasattr(fp, p):
                 return
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "CurvedSegment",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
         if prop in proplist:      
             self.execute(fp)
             
@@ -133,7 +136,7 @@ class CurvedSegmentWorker:
             self.rescaleRibs(fp, ribs)
             
         if fp.makeSurface or fp.makeSolid:
-            fp.Shape = CurvedShapes.makeSurfaceSolid(ribs, fp.makeSolid)
+            fp.Shape = CurvedShapes.makeSurfaceSolid(ribs, fp.makeSolid, maxDegree=fp.LoftMaxDegree)
         else:
             fp.Shape = Part.makeCompound(ribs)          
         

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -8,6 +8,20 @@ import CompoundTools.Explode
 
 epsilon = 1e-7
 
+
+def addObjectProperty(obj, ptype, pname, *args, init_val=None):
+    """
+    Adds a property to the object if it does not exist yet - important for upgrading CAD files from older versions of the plugin
+    """
+    added = False
+    if pname not in obj.PropertiesList:
+        added = obj.addProperty(ptype, pname, *args)
+    if init_val is None:
+        return obj
+    if added:
+        setattr(obj, pname, init_val)
+    return obj
+
 def get_module_path():
     """ Returns the current module path.
     Determines where this file is running from, so works regardless of whether
@@ -161,7 +175,7 @@ def scaleByBoundbox(shape, boundbox, doScaleXYZ, copy=True):
     return dolly
     
             
-def makeSurfaceSolid(ribs, solid):
+def makeSurfaceSolid(ribs, solid, maxDegree=5):
     surfaces = []
 
     wiribs = []
@@ -175,8 +189,8 @@ def makeSurfaceSolid(ribs, solid):
                 FreeCAD.Console.PrintError("Cannot make a wire. Creation of surface is not possible !\n")
                 return
           
-    try: 
-        loft = Part.makeLoft(wiribs)
+    try:
+        loft = Part.makeLoft(wiribs,False,False,False,maxDegree)
         surfaces += loft.Faces
     except Exception as ex:      
         FreeCAD.Console.PrintError("Creation of surface is not possible !\n")

--- a/InterpolatedMiddle.py
+++ b/InterpolatedMiddle.py
@@ -26,16 +26,18 @@ class InterpolatedMiddleWorker:
                  solid=False,
                  InterpolationPoints=16,
                  Twist = 0.0,
-                 TwistReverse = False):
-        fp.addProperty("App::PropertyLink",  "Shape1",     "InterpolatedMiddle",   "The first object of the segment").Shape1 = shape1
-        fp.addProperty("App::PropertyLink",  "Shape2",     "InterpolatedMiddle",   "The last object of the segment").Shape2 = shape2     
-        fp.addProperty("App::PropertyVector", "NormalShape1",    "InterpolatedMiddle",   "Direction axis of Shape1").NormalShape1 = normalShape1 
-        fp.addProperty("App::PropertyVector", "NormalShape2",    "InterpolatedMiddle",   "Direction axis of Shape2").NormalShape1 = normalShape2
-        fp.addProperty("App::PropertyBool", "makeSurface","InterpolatedMiddle",  "make a surface").makeSurface = surface
-        fp.addProperty("App::PropertyBool", "makeSolid","InterpolatedMiddle",  "make a solid").makeSolid = solid
-        fp.addProperty("App::PropertyInteger", "InterpolationPoints", "InterpolatedMiddle",   "Unequal edges will be split into this number of points").InterpolationPoints = InterpolationPoints
-        fp.addProperty("App::PropertyFloat", "Twist","InterpolatedMiddle",  "Compensates a rotation between Shape1 and Shape2").Twist = Twist
-        fp.addProperty("App::PropertyBool", "TwistReverse","InterpolatedMiddle",  "Reverses the rotation of one Shape").TwistReverse = TwistReverse
+                 TwistReverse = False,
+                 LoftMaxDegree=5):
+        CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "InterpolatedMiddle",   "The first object of the segment").Shape1 = shape1
+        CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "InterpolatedMiddle",   "The last object of the segment").Shape2 = shape2     
+        CurvedShapes.addObjectProperty(fp,"App::PropertyVector", "NormalShape1",    "InterpolatedMiddle",   "Direction axis of Shape1").NormalShape1 = normalShape1 
+        CurvedShapes.addObjectProperty(fp,"App::PropertyVector", "NormalShape2",    "InterpolatedMiddle",   "Direction axis of Shape2").NormalShape1 = normalShape2
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "makeSurface","InterpolatedMiddle",  "make a surface").makeSurface = surface
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "makeSolid","InterpolatedMiddle",  "make a solid").makeSolid = solid
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "InterpolationPoints", "InterpolatedMiddle",   "Unequal edges will be split into this number of points").InterpolationPoints = InterpolationPoints
+        CurvedShapes.addObjectProperty(fp,"App::PropertyFloat", "Twist","InterpolatedMiddle",  "Compensates a rotation between Shape1 and Shape2").Twist = Twist
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "TwistReverse","InterpolatedMiddle",  "Reverses the rotation of one Shape").TwistReverse = TwistReverse
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "InterpolatedMiddle",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
         self.update = True
         fp.Proxy = self
  
@@ -70,6 +72,7 @@ class InterpolatedMiddleWorker:
         for p in proplist:
             if not hasattr(fp, p):
                 return
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "InterpolatedMiddle",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents)
          
         if prop in proplist:  
             self.execute(fp)
@@ -98,9 +101,9 @@ class InterpolatedMiddleWorker:
             
         if (fp.makeSurface or fp.makeSolid) and len(ribs) == 1:
             rib1 = [fp.Shape1.Shape, ribs[0]]
-            shape1 = CurvedShapes.makeSurfaceSolid(rib1, False)
+            shape1 = CurvedShapes.makeSurfaceSolid(rib1, False, maxDegree=fp.LoftMaxDegree)
             rib2 = [ribs[0], fp.Shape2.Shape]
-            shape2 = CurvedShapes.makeSurfaceSolid(rib2, False)
+            shape2 = CurvedShapes.makeSurfaceSolid(rib2, False, maxDegree=fp.LoftMaxDegree)
             
             shape = Part.makeCompound([shape1, shape2])
             


### PR DESCRIPTION
Implementation for Feauture Request #36 
This allows fixing a few cases where freecad crashes or produces crap solids/surfaces for curved arrays and segments because the loft generation interpolation is too smart for its own good. a default value of "2" would be better than the default 5, but for backwards compatibility the default has been kept.

This has been implemented in a backwards-compatible way - i.e. the new property is automatically added if a file created with an older version is edited (using the default value)

see help(Part.makeLoft) :
```
Help on built-in function makeLoft:

makeLoft(...) method of builtins.tuple instance
    makeLoft(list of wires,[solid=False,ruled=False,closed=False,maxDegree=5]) -- Create a loft shape.
```
