### PR TITLE
execute should not be called from onChanged

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -205,8 +205,6 @@ class CurvedArrayWorker:
                 if outOfBounds:
                     FreeCAD.Console.PrintWarning("Some positions are out of bounds, should all be between 0.0 and 1.0, inclusive\n")
 
-            self.execute(fp)
-
 
 class CurvedArrayViewProvider:
     def __init__(self, vobj):

--- a/CurvedPathArray.py
+++ b/CurvedPathArray.py
@@ -184,9 +184,6 @@ class CurvedPathArrayWorker:
             if not hasattr(fp, p):
                 return 
             
-        if prop in proplist:      
-            self.execute(fp)
-
 
 class CurvedPathArrayViewProvider:
     def __init__(self, vobj):

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -103,9 +103,6 @@ class CurvedSegmentWorker:
         for p in proplist:
             if not hasattr(fp, p):
                 return
-        if prop in proplist:      
-            self.execute(fp)
-            
             
     def makeRibs(self, fp):
         interpolate = False

--- a/InterpolatedMiddle.py
+++ b/InterpolatedMiddle.py
@@ -70,11 +70,7 @@ class InterpolatedMiddleWorker:
         for p in proplist:
             if not hasattr(fp, p):
                 return
-         
-        if prop in proplist:  
-            self.execute(fp)
-                      
-            
+
     def makeRibs(self, fp):
         interpolate = False
         if len(fp.Shape1.Shape.Edges) != len(fp.Shape2.Shape.Edges):

--- a/NotchConnector.py
+++ b/NotchConnector.py
@@ -32,14 +32,10 @@ class NotchConnectorWorker:
         
     def onChanged(self, fp, prop):
         proplist = ["Base", "Tools", "CutDirection", "ShiftLength"]
-        if prop in proplist:      
-            self.execute(fp)
             
         if prop == "CutDepth" and fp.CutDirection != Vector(0.0,0.0,0.0):
             cdep = 100 - abs(fp.CutDepth)
             fp.CutDirection = fp.CutDirection.normalize() * cdep / 50
-            self.execute(fp)
-            
             
     def execute(self, fp):
         if not fp.Base or not fp.Tools:

--- a/SurfaceCut.py
+++ b/SurfaceCut.py
@@ -36,8 +36,6 @@ class SurfaceCutWorker:
      
     def onChanged(self, fp, prop):
         props = ["Surfaces", "Position", "Normal", "Simplify"]
-        if prop in props:
-            self.execute(fp)  
             
         if prop == "Face":
             if fp.Face == True:


### PR DESCRIPTION
calling execute from onchanged slows freecad down because the computation that should only happen on a full recompute happens every time the value changes (including during typing if the user deletes and enters a multi digit number in the interface)

worse, onChanged is called during startup of freecad / when the file loads before all entities have been initialized, which causes computation errors (loft fails to create, etc...)

fixes issue #27 