### PR TITLE
Introduce new parameters for segmented lofts for less buggy curved shapes and faster rendering

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -32,7 +32,8 @@ class CurvedArray:
                  DistributionReverse = False,
                  extract=False,
                  Twists = [],
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(obj, "App::PropertyLink",  "Base",     "CurvedArray",   "The object to make an array from").Base = base
         CurvedShapes.addObjectProperty(obj, "App::PropertyLinkList",  "Hullcurves",   "CurvedArray",   "Bounding curves").Hullcurves = hullcurves        
         CurvedShapes.addObjectProperty(obj, "App::PropertyVector", "Axis",    "CurvedArray",   "Direction axis").Axis = axis
@@ -47,6 +48,7 @@ class CurvedArray:
         CurvedShapes.addObjectProperty(obj, "App::PropertyEnumeration", "Distribution", "CurvedArray",  "Algorithm for distance between elements")
         CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "DistributionReverse", "CurvedArray",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
         CurvedShapes.addObjectProperty(obj, "App::PropertyInteger", "LoftMaxDegree", "CurvedArray",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "MaxLoftSize", "CurvedArray",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         obj.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         obj.Distribution = Distribution
         self.extract = extract
@@ -113,7 +115,7 @@ class CurvedArray:
 
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
-            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree)
+            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree, maxLoftSize=obj.MaxLoftSize)
         else:
             obj.Shape = Part.makeCompound(ribs)
             
@@ -193,6 +195,8 @@ class CurvedArray:
     def onChanged(self, fp, prop):            
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedArray",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedArray",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
            
         if "Positions" in prop and len(fp.Positions) != 0:
             setattr(fp,"Items",str(len(fp.Positions)))

--- a/CurvedPathArray.py
+++ b/CurvedPathArray.py
@@ -30,7 +30,8 @@ class CurvedPathArray:
                  Solid = False,
                  doScale = [],
                  extract=False,
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(obj,"App::PropertyLink",  "Base",     "CurvedPathArray",   "The object to make an array from").Base = base
         CurvedShapes.addObjectProperty(obj,"App::PropertyLink",  "Path",     "CurvedPathArray",   "Sweep path").Path = path
         CurvedShapes.addObjectProperty(obj,"App::PropertyLinkList",  "Hullcurves",   "CurvedPathArray",   "Bounding curves").Hullcurves = hullcurves   
@@ -44,6 +45,7 @@ class CurvedPathArray:
         CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleY","CurvedPathArray",  "Scale by hullcurves in Y direction").ScaleY = True
         CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleZ","CurvedPathArray",  "Scale by hullcurves in Z direction").ScaleZ = True
         CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "LoftMaxDegree", "CurvedPathArray",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "MaxLoftSize", "CurvedPathArray",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         self.doScaleXYZsum = [False, False, False]
         if len(doScale) == 3:
             obj.ScaleX = doScale[0]
@@ -134,7 +136,7 @@ class CurvedPathArray:
         
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
-            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree)
+            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree, maxLoftSize=obj.MaxLoftSize)
         else:
             obj.Shape = Part.makeCompound(ribs)
             
@@ -184,6 +186,8 @@ class CurvedPathArray:
     def onChanged(self, fp, prop):
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedPathArray",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedPathArray",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
             
 #background compatibility
 CurvedPathArrayWorker = CurvedPathArray

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -32,7 +32,8 @@ class CurvedSegment:
                  TwistReverse = False,
                  Distribution = 'linear',
                  DistributionReverse = False,
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "CurvedSegment",   "The first object of the segment").Shape1 = shape1
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "CurvedSegment",   "The last object of the segment").Shape2 = shape2
         CurvedShapes.addObjectProperty(fp,"App::PropertyLinkList",  "Hullcurves",   "CurvedSegment",   "Bounding curves").Hullcurves = hullcurves        
@@ -47,6 +48,7 @@ class CurvedSegment:
         CurvedShapes.addObjectProperty(fp,"App::PropertyEnumeration", "Distribution", "CurvedSegment",  "Algorithm for distance between elements")
         CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "DistributionReverse", "CurvedSegment",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
         CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "CurvedSegment",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedSegment",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         fp.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         fp.Distribution = Distribution
         self.doScaleXYZ = []
@@ -104,6 +106,8 @@ class CurvedSegment:
     def onChanged(self, fp, prop):   
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedSegment",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedSegment",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
 
             
     def makeRibs(self, fp):
@@ -132,7 +136,7 @@ class CurvedSegment:
             self.rescaleRibs(fp, ribs)
             
         if fp.makeSurface or fp.makeSolid:
-            fp.Shape = CurvedShapes.makeSurfaceSolid(ribs, fp.makeSolid, maxDegree=fp.LoftMaxDegree)
+            fp.Shape = CurvedShapes.makeSurfaceSolid(ribs, fp.makeSolid, maxDegree=fp.LoftMaxDegree, maxLoftSize=fp.MaxLoftSize)
         else:
             fp.Shape = Part.makeCompound(ribs)          
         

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -337,10 +337,11 @@ def makeCurvedArray(Base = None,
                     DistributionReverse = False,
                     extract=False,
                     Twists = [],
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import CurvedArray
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedArray")
-    CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree)
+    CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         CurvedArray.CurvedArrayViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()
@@ -363,10 +364,11 @@ def makeCurvedPathArray(Base = None,
                     Solid=False, 
                     doScale = [True, True, True],
                     extract=False,
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import CurvedPathArray
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedPathArray")
-    CurvedPathArray.CurvedPathArray(obj, Base, Path, Hullcurves, Items, OffsetStart, OffsetEnd, Twist, Surface, Solid, doScale, extract, LoftMaxDegree)
+    CurvedPathArray.CurvedPathArray(obj, Base, Path, Hullcurves, Items, OffsetStart, OffsetEnd, Twist, Surface, Solid, doScale, extract, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         CurvedPathArray.CurvedPathArrayViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()
@@ -386,10 +388,11 @@ def makeCurvedSegment(Shape1 = None,
                     TwistReverse = False,
                     Distribution = 'linear',
                     DistributionReverse = False,
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import CurvedSegment
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedSegment")
-    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree)
+    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         CurvedSegment.CurvedSegmentViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()
@@ -405,10 +408,11 @@ def makeInterpolatedMiddle(Shape1 = None,
                     InterpolationPoints=16,
                     Twist = 0.0,
                     TwistReverse = False,
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import InterpolatedMiddle
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","InterpolatedMiddle")
-    InterpolatedMiddle.InterpolatedMiddle(obj, Shape1, Shape2, NormalShape1, NormalShape2, Surface, Solid, InterpolationPoints, Twist, TwistReverse, LoftMaxDegree)
+    InterpolatedMiddle.InterpolatedMiddle(obj, Shape1, Shape2, NormalShape1, NormalShape2, Surface, Solid, InterpolationPoints, Twist, TwistReverse, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         InterpolatedMiddle.InterpolatedMiddleViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()

--- a/InterpolatedMiddle.py
+++ b/InterpolatedMiddle.py
@@ -28,7 +28,8 @@ class InterpolatedMiddle:
                  InterpolationPoints=16,
                  Twist = 0.0,
                  TwistReverse = False,
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "InterpolatedMiddle",   "The first object of the segment").Shape1 = shape1
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "InterpolatedMiddle",   "The last object of the segment").Shape2 = shape2     
         CurvedShapes.addObjectProperty(fp,"App::PropertyVector", "NormalShape1",    "InterpolatedMiddle",   "Direction axis of Shape1").NormalShape1 = normalShape1 
@@ -39,6 +40,7 @@ class InterpolatedMiddle:
         CurvedShapes.addObjectProperty(fp,"App::PropertyFloat", "Twist","InterpolatedMiddle",  "Compensates a rotation between Shape1 and Shape2").Twist = Twist
         CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "TwistReverse","InterpolatedMiddle",  "Reverses the rotation of one Shape").TwistReverse = TwistReverse
         CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "InterpolatedMiddle",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "InterpolatedMiddle",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         self.update = True
         fp.Proxy = self
  
@@ -71,6 +73,8 @@ class InterpolatedMiddle:
     def onChanged(self, fp, prop):
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "InterpolatedMiddle",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "InterpolatedMiddle",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
 
 
     def makeRibs(self, fp):
@@ -96,9 +100,9 @@ class InterpolatedMiddle:
             
         if (fp.makeSurface or fp.makeSolid) and len(ribs) == 1:
             rib1 = [fp.Shape1.Shape, ribs[0]]
-            shape1 = CurvedShapes.makeSurfaceSolid(rib1, False, maxDegree=fp.LoftMaxDegree)
+            shape1 = CurvedShapes.makeSurfaceSolid(rib1, False, maxDegree=fp.LoftMaxDegree, maxLoftSize=fp.MaxLoftSize)
             rib2 = [ribs[0], fp.Shape2.Shape]
-            shape2 = CurvedShapes.makeSurfaceSolid(rib2, False, maxDegree=fp.LoftMaxDegree)
+            shape2 = CurvedShapes.makeSurfaceSolid(rib2, False, maxDegree=fp.LoftMaxDegree, maxLoftSize=fp.MaxLoftSize)
             
             shape = Part.makeCompound([shape1, shape2])
             


### PR DESCRIPTION
( Fix #40 )

This patch introduces a new parameter for the shape - MaxLoftSize - which is the maximum number of profiles that should be covered by a single loft - applicable for CurvedArray, CurvedPathArray, CurvedSegment and InterpolatedMIddle.

Shapes with more items than MaxLoftSize will be segmented, it will still be a single shape, but consisting oft multiple curves over subsegment. The default  set in the PR is 16 segments for newly created shapes, and (-1) for existing files.
0 or negative value disables this new feature, forcing a single loft over the whole curvedshape - the old behaviour.

good values are over 10 and under 100 -- above 100 FreeCAD gets very slow and the results start showing buggy artefacts - under 10, the shape might not math very well. The user can finetune the number and the profile placement to prevent the segment boundaries from distorting the shape (although usually OCC does a good job at continuing a smooth shape on both sides)

The feature has some inbuilt smarts to prevent very small  sections from getting created. the smallest section that can appear is MaxLoftSize/2 in size. if the number of profiles is not a multiple of MaxLoftSize, then always the last or last 2 sections end up smaller.
