### PR TITLE
CurvedSegments on a Path

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -32,7 +32,8 @@ class CurvedArray:
                  DistributionReverse = False,
                  extract=False,
                  Twists = [],
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(obj, "App::PropertyLink",  "Base",     "CurvedArray",   "The object to make an array from").Base = base
         CurvedShapes.addObjectProperty(obj, "App::PropertyLinkList",  "Hullcurves",   "CurvedArray",   "Bounding curves").Hullcurves = hullcurves        
         CurvedShapes.addObjectProperty(obj, "App::PropertyVector", "Axis",    "CurvedArray",   "Direction axis").Axis = axis
@@ -47,6 +48,7 @@ class CurvedArray:
         CurvedShapes.addObjectProperty(obj, "App::PropertyEnumeration", "Distribution", "CurvedArray",  "Algorithm for distance between elements")
         CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "DistributionReverse", "CurvedArray",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
         CurvedShapes.addObjectProperty(obj, "App::PropertyInteger", "LoftMaxDegree", "CurvedArray",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "MaxLoftSize", "CurvedArray",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         obj.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         obj.Distribution = Distribution
         self.extract = extract
@@ -113,7 +115,7 @@ class CurvedArray:
 
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
-            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree)
+            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree, maxLoftSize=obj.MaxLoftSize)
         else:
             obj.Shape = Part.makeCompound(ribs)
             
@@ -193,6 +195,8 @@ class CurvedArray:
     def onChanged(self, fp, prop):            
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedArray",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedArray",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
            
         if "Positions" in prop and len(fp.Positions) != 0:
             setattr(fp,"Items",str(len(fp.Positions)))

--- a/CurvedPathArray.py
+++ b/CurvedPathArray.py
@@ -30,7 +30,8 @@ class CurvedPathArray:
                  Solid = False,
                  doScale = [],
                  extract=False,
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(obj,"App::PropertyLink",  "Base",     "CurvedPathArray",   "The object to make an array from").Base = base
         CurvedShapes.addObjectProperty(obj,"App::PropertyLink",  "Path",     "CurvedPathArray",   "Sweep path").Path = path
         CurvedShapes.addObjectProperty(obj,"App::PropertyLinkList",  "Hullcurves",   "CurvedPathArray",   "Bounding curves").Hullcurves = hullcurves   
@@ -44,6 +45,7 @@ class CurvedPathArray:
         CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleY","CurvedPathArray",  "Scale by hullcurves in Y direction").ScaleY = True
         CurvedShapes.addObjectProperty(obj,"App::PropertyBool", "ScaleZ","CurvedPathArray",  "Scale by hullcurves in Z direction").ScaleZ = True
         CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "LoftMaxDegree", "CurvedPathArray",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "MaxLoftSize", "CurvedPathArray",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         self.doScaleXYZsum = [False, False, False]
         if len(doScale) == 3:
             obj.ScaleX = doScale[0]
@@ -134,7 +136,7 @@ class CurvedPathArray:
         
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
-            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree)
+            obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree, maxLoftSize=obj.MaxLoftSize)
         else:
             obj.Shape = Part.makeCompound(ribs)
             
@@ -184,6 +186,8 @@ class CurvedPathArray:
     def onChanged(self, fp, prop):
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedPathArray",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedPathArray",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
             
 #background compatibility
 CurvedPathArrayWorker = CurvedPathArray

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -32,7 +32,8 @@ class CurvedSegment:
                  TwistReverse = False,
                  Distribution = 'linear',
                  DistributionReverse = False,
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "CurvedSegment",   "The first object of the segment").Shape1 = shape1
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "CurvedSegment",   "The last object of the segment").Shape2 = shape2
         CurvedShapes.addObjectProperty(fp,"App::PropertyLinkList",  "Hullcurves",   "CurvedSegment",   "Bounding curves").Hullcurves = hullcurves        
@@ -47,6 +48,7 @@ class CurvedSegment:
         CurvedShapes.addObjectProperty(fp,"App::PropertyEnumeration", "Distribution", "CurvedSegment",  "Algorithm for distance between elements")
         CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "DistributionReverse", "CurvedSegment",  "Reverses direction of Distribution algorithm").DistributionReverse = DistributionReverse
         CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "CurvedSegment",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedSegment",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         fp.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         fp.Distribution = Distribution
         self.doScaleXYZ = []
@@ -104,6 +106,8 @@ class CurvedSegment:
     def onChanged(self, fp, prop):   
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "CurvedSegment",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedSegment",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
 
             
     def makeRibs(self, fp):
@@ -132,7 +136,7 @@ class CurvedSegment:
             self.rescaleRibs(fp, ribs)
             
         if fp.makeSurface or fp.makeSolid:
-            fp.Shape = CurvedShapes.makeSurfaceSolid(ribs, fp.makeSolid, maxDegree=fp.LoftMaxDegree)
+            fp.Shape = CurvedShapes.makeSurfaceSolid(ribs, fp.makeSolid, maxDegree=fp.LoftMaxDegree, maxLoftSize=fp.MaxLoftSize)
         else:
             fp.Shape = Part.makeCompound(ribs)          
         

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -172,6 +172,7 @@ class CurvedSegment:
             normal = CurvedShapes.vectorMiddle(fp.NormalShape1, fp.NormalShape2, d)
             #Draft.makeLine(ribs[i].BoundBox.Center, ribs[i].BoundBox.Center + normal)
             ribs[i] = ribs[i].rotate(bc0+d*(bc1-bc0), normal, fp.ActualTwist * d)
+            direction = normal
             if maxlen>0:
                 plen = d * maxlen
                 for edge in edges:
@@ -188,7 +189,7 @@ class CurvedSegment:
                         ribs[i].Placement.Base = posvec
 
             if len(fp.Hullcurves) > 0:
-                bbox = CurvedShapes.boundbox_from_intersect(fp.Hullcurves, ribs[i].BoundBox.Center, normal, self.doScaleXYZ)
+                bbox = CurvedShapes.boundbox_from_intersect(fp.Hullcurves, ribs[i].BoundBox.Center, direction, self.doScaleXYZ)
                 if bbox:              
                     ribs[i] = CurvedShapes.scaleByBoundbox(ribs[i], bbox, self.doScaleXYZsum, copy=False)
 

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -148,7 +148,7 @@ class CurvedSegment:
         
         
     def rescaleRibs(self, fp, ribs):
-        if (fp.makeSurface or fp.makeSolid) and fp.Path is None:
+        if (fp.makeSurface or fp.makeSolid) and fp.Path is None and abs(fp.ActualTwist)<=epsilon:
             start = 1
             end = len(ribs) - 1
             items = fp.Items + 3
@@ -245,7 +245,7 @@ def makeRibsSameShape(fp, items, alongNormal, makeStartEnd = False):
     base1=fp.Shape1.Placement.Base
     base2=fp.Shape2.Placement.Base
     offset=base2-base1
-    if makeStartEnd and (fp.Path is not None):
+    if makeStartEnd and ((fp.Path is not None) or (abs(fp.ActualTwist)>epsilon)):
         start=0
         end=items+2
     else:
@@ -301,7 +301,7 @@ def makeRibsSameShape(fp, items, alongNormal, makeStartEnd = False):
                 ribs.append(Part.makeCompound(curves))
         ribs[-1].Placement.Base=fraction*offset #place the whole rib in the right place instead
             
-    if makeStartEnd and fp.Path is None:
+    if makeStartEnd and fp.Path is None and abs(fp.ActualTwist)<=epsilon:
         ribs.insert(0, fp.Shape1.Shape)
         ribs.append(fp.Shape2.Shape)
         

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -337,10 +337,11 @@ def makeCurvedArray(Base = None,
                     DistributionReverse = False,
                     extract=False,
                     Twists = [],
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import CurvedArray
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedArray")
-    CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree)
+    CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         CurvedArray.CurvedArrayViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()
@@ -363,10 +364,11 @@ def makeCurvedPathArray(Base = None,
                     Solid=False, 
                     doScale = [True, True, True],
                     extract=False,
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import CurvedPathArray
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedPathArray")
-    CurvedPathArray.CurvedPathArray(obj, Base, Path, Hullcurves, Items, OffsetStart, OffsetEnd, Twist, Surface, Solid, doScale, extract, LoftMaxDegree)
+    CurvedPathArray.CurvedPathArray(obj, Base, Path, Hullcurves, Items, OffsetStart, OffsetEnd, Twist, Surface, Solid, doScale, extract, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         CurvedPathArray.CurvedPathArrayViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()
@@ -386,10 +388,11 @@ def makeCurvedSegment(Shape1 = None,
                     TwistReverse = False,
                     Distribution = 'linear',
                     DistributionReverse = False,
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import CurvedSegment
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedSegment")
-    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree)
+    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         CurvedSegment.CurvedSegmentViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()
@@ -405,10 +408,11 @@ def makeInterpolatedMiddle(Shape1 = None,
                     InterpolationPoints=16,
                     Twist = 0.0,
                     TwistReverse = False,
-                    LoftMaxDegree=5):
+                    LoftMaxDegree=5,
+                    MaxLoftSize=16):
     import InterpolatedMiddle
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","InterpolatedMiddle")
-    InterpolatedMiddle.InterpolatedMiddle(obj, Shape1, Shape2, NormalShape1, NormalShape2, Surface, Solid, InterpolationPoints, Twist, TwistReverse, LoftMaxDegree)
+    InterpolatedMiddle.InterpolatedMiddle(obj, Shape1, Shape2, NormalShape1, NormalShape2, Surface, Solid, InterpolationPoints, Twist, TwistReverse, LoftMaxDegree, MaxLoftSize)
     if FreeCAD.GuiUp:
         InterpolatedMiddle.InterpolatedMiddleViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -390,10 +390,11 @@ def makeCurvedSegment(Shape1 = None,
                     DistributionReverse = False,
                     LoftMaxDegree=5,
                     MaxLoftSize=16,
-                    ActualTwist = 0.0):
+                    ActualTwist = 0.0,
+                    Path = None):
     import CurvedSegment
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedSegment")
-    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize, ActualTwist)
+    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize, ActualTwist, Path)
     if FreeCAD.GuiUp:
         CurvedSegment.CurvedSegmentViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -389,10 +389,11 @@ def makeCurvedSegment(Shape1 = None,
                     Distribution = 'linear',
                     DistributionReverse = False,
                     LoftMaxDegree=5,
-                    MaxLoftSize=16):
+                    MaxLoftSize=16,
+                    ActualTwist = 0.0):
     import CurvedSegment
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedSegment")
-    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize)
+    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize, ActualTwist)
     if FreeCAD.GuiUp:
         CurvedSegment.CurvedSegmentViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()

--- a/InterpolatedMiddle.py
+++ b/InterpolatedMiddle.py
@@ -28,7 +28,8 @@ class InterpolatedMiddle:
                  InterpolationPoints=16,
                  Twist = 0.0,
                  TwistReverse = False,
-                 LoftMaxDegree=5):
+                 LoftMaxDegree=5,
+                 MaxLoftSize=16):
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "InterpolatedMiddle",   "The first object of the segment").Shape1 = shape1
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "InterpolatedMiddle",   "The last object of the segment").Shape2 = shape2     
         CurvedShapes.addObjectProperty(fp,"App::PropertyVector", "NormalShape1",    "InterpolatedMiddle",   "Direction axis of Shape1").NormalShape1 = normalShape1 
@@ -39,6 +40,7 @@ class InterpolatedMiddle:
         CurvedShapes.addObjectProperty(fp,"App::PropertyFloat", "Twist","InterpolatedMiddle",  "Compensates a rotation between Shape1 and Shape2").Twist = Twist
         CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "TwistReverse","InterpolatedMiddle",  "Reverses the rotation of one Shape").TwistReverse = TwistReverse
         CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "LoftMaxDegree", "InterpolatedMiddle",   "Max Degree for Surface or Solid").LoftMaxDegree = LoftMaxDegree
+        CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "InterpolatedMiddle",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         self.update = True
         fp.Proxy = self
  
@@ -71,6 +73,8 @@ class InterpolatedMiddle:
     def onChanged(self, fp, prop):
         if not hasattr(fp, 'LoftMaxDegree'):
             CurvedShapes.addObjectProperty(fp, "App::PropertyInteger", "LoftMaxDegree", "InterpolatedMiddle",   "Max Degree for Surface or Solid", init_val=5) # backwards compatibility - this upgrades older documents
+        if not hasattr(fp, 'MaxLoftSize'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "InterpolatedMiddle",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
 
 
     def makeRibs(self, fp):
@@ -96,9 +100,9 @@ class InterpolatedMiddle:
             
         if (fp.makeSurface or fp.makeSolid) and len(ribs) == 1:
             rib1 = [fp.Shape1.Shape, ribs[0]]
-            shape1 = CurvedShapes.makeSurfaceSolid(rib1, False, maxDegree=fp.LoftMaxDegree)
+            shape1 = CurvedShapes.makeSurfaceSolid(rib1, False, maxDegree=fp.LoftMaxDegree, maxLoftSize=fp.MaxLoftSize)
             rib2 = [ribs[0], fp.Shape2.Shape]
-            shape2 = CurvedShapes.makeSurfaceSolid(rib2, False, maxDegree=fp.LoftMaxDegree)
+            shape2 = CurvedShapes.makeSurfaceSolid(rib2, False, maxDegree=fp.LoftMaxDegree, maxLoftSize=fp.MaxLoftSize)
             
             shape = Part.makeCompound([shape1, shape2])
             

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The first curve that you select for CurvedArray creation will be the item that i
 - Distribution: Algorithm for distance between array elements. Default is 'linear'. Also selectable: parabolic (x²), x³, sinusoidal, asinusoidal, elliptic
 - DistributionReverse: Reverses the direction of the Distribution algorithm
 - LoftMaxDegree: degree for surface or solid creation. Play with this parameter if your surface or solid looks distorted
+- MaxLoftSize: Maximum size of a loft segment. The surface is created by creating a loft over many array items, however OpenCascade gets very slow and produces artefacts towards the end of the loft when the array gets too large. Therefore the array gets split up intp sub-arrays of up to MaxLoftSize items. Play with this value if a split between segements ends up in a inconvenient spot. Sensible values are between 10 and 50.
 
 Distribution Linear  
 ![Linear](Examples/CurvedArrayLinear.jpg)  
@@ -104,6 +105,7 @@ The first curve that you select for Curved Path Array creation will be the base 
 - ScaleY: Scale by hullcurves in Y direction
 - ScaleZ: Scale by hullcurves in Z direction
 - LoftMaxDegree: degree for surface or solid creation. Play with this parameter if your surface or solid looks distorted
+- MaxLoftSize: Maximum size of a loft segment. The surface is created by creating a loft over many array items, however OpenCascade gets very slow and produces artefacts towards the end of the loft when the array gets too large. Therefore the array gets split up intp sub-arrays of up to MaxLoftSize items. Play with this value if a split between segements ends up in a inconvenient spot. Sensible values are between 10 and 50.
 
 The parameters ScaleX, ScaleY and ScaleZ have been added because you may want to rescale the items only in one direction, but the hullcurves normally cover 2 or three room directions.  
   
@@ -125,11 +127,14 @@ Select two 2D shapes first. The curved segment will be created between them. If 
 - makeSurface: make a surface over the array items
 - makeSolid: make a solid if Base is a closed shape
 - InterpolationPoints: ignored if Shape1 and Shape2 have the same number of edges and poles. Otherwise all edges will be split (discretized) into this number of points
-- Twist: Compensates a rotation between Shape1 and Shape2
-- TwistReverse: Reverses the rotation of one Shape
+- Twist: Compensates a rotation between Shape1 and Shape2. This is for correcting misalignment between the shapes, use this if the segments to not match up.
+- TwistReverse: Reverses the rotation of one Shape. This is for correcting misalignment between the shapes, use this if the entire shape is inversed on itself (wasp-tail)
+- ActualTwist: Introduce a deliberate twist into the shape around the profiles normal axis, similar to "Twist" in CurvedArray and CurvedPathArray. Useful for example for threaded parts.
+- Path: Sweep path - similar to "Path" in CurvedPathArray. If a path is specified, it supersedes the position and orientation of Shape1 and Shape2. CurvedSegment then behaves like CurvedPathArray but with a blend between a beginning and end profile.
 - Distribution: Algorithm for distance between array elements. Default is 'linear'. Also selectable: parabolic (x²), x³, sinusoidal, elliptic
 - DistributionReverse: Reverses the direction of the Distribution algorithm
 - LoftMaxDegree: degree for surface or solid creation. Play with this parameter if your surface or solid looks distorted
+- MaxLoftSize: Maximum size of a loft segment. The surface is created by creating a loft over many array items, however OpenCascade gets very slow and produces artefacts towards the end of the loft when the array gets too large. Therefore the array gets split up intp sub-arrays of up to MaxLoftSize items. Play with this value if a split between segements ends up in a inconvenient spot. Sensible values are between 10 and 50.
 
 ### ![CornerShapeIcon](./Resources/icons/CornerShape.svg) Interpolated Middle
 Interpolates a 2D shape into the middle between two 2D curves. The base shapes can be connected to a shape with a sharp corner.
@@ -148,6 +153,7 @@ Interpolates a 2D shape into the middle between two 2D curves. The base shapes c
 - Twist: Compensates a rotation between Shape1 and Shape2
 - TwistReverse: Reverses the rotation of one Shape
 - LoftMaxDegree: degree for surface or solid creation. Play with this parameter if your surface or solid looks distorted
+- MaxLoftSize: Maximum size of a loft segment. The surface is created by creating a loft over many array items, however OpenCascade gets very slow and produces artefacts towards the end of the loft when the array gets too large. Therefore the array gets split up intp sub-arrays of up to MaxLoftSize items. Play with this value if a split between segements ends up in a inconvenient spot. Sensible values are between 10 and 50.
   
   
 ### ![surfaceCutIcon](./Resources/icons/surfaceCut.svg) Surface Cut


### PR DESCRIPTION
Depends on twisted curved segments.

Allows for curved segments to be placed on a path for arbitrary segment shapes - overrides the position and orientation of the defining shapes when used, the resulting shape uses the path (and hullcurves) only.
fix #44

example image:
![twisted_screw](https://github.com/user-attachments/assets/35e5e273-a880-44ab-a01d-8929a000f6f7)

[twisted_screw2.zip](https://github.com/user-attachments/files/17187561/twisted_screw2.zip)
