### PR TITLE
Cummulative PR - Also add optional interpolation and fix for fixed, wrongly oriented directional curve elements (circle sectors) in sketches

### DIFF
--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -316,17 +316,19 @@ def makeRibsSameShape(fp, items, alongNormal, makeStartEnd = False):
     return ribs
                 
  
-def makeRibsInterpolate(fp, items, alongNormal, makeStartEnd = False):       
-    len1 = len(fp.Shape1.Shape.Edges)
-    len2 = len(fp.Shape2.Shape.Edges)
+def makeRibsInterpolate(fp, items, alongNormal, makeStartEnd = False):
+    s1=fp.Shape1.Shape.toNurbs()
+    s2=fp.Shape2.Shape.toNurbs()
+    len1 = len(s1.Edges)
+    len2 = len(s2.Edges)
     twist = fp.Twist
     if len2 > 1:
         twist = 0
     
     nr_edges = int(len1 * len2 / math.gcd(len1, len2))
 
-    pointslist1 = EdgesToPoints(fp.Shape1.Shape, int(nr_edges / len1), int(fp.InterpolationPoints))
-    pointslist2 = EdgesToPoints(fp.Shape2.Shape, int(nr_edges / len2), int(fp.InterpolationPoints), fp.Twist, fp.TwistReverse)
+    pointslist1 = EdgesToPoints(s1, int(nr_edges / len1), int(fp.InterpolationPoints))
+    pointslist2 = EdgesToPoints(s2, int(nr_edges / len2), int(fp.InterpolationPoints), fp.Twist, fp.TwistReverse)
             
     ribs = []
     if makeStartEnd:
@@ -336,8 +338,8 @@ def makeRibsInterpolate(fp, items, alongNormal, makeStartEnd = False):
         start = 1
         end = items + 1 
         
-    base1=fp.Shape1.Placement.Base
-    base2=fp.Shape2.Placement.Base
+    base1=s1.Placement.Base
+    base2=s2.Placement.Base
     offset=base2-base1
     for i in range(start, end):
         if hasattr(fp, "Distribution"):
@@ -387,7 +389,8 @@ def makeRibsInterpolate(fp, items, alongNormal, makeStartEnd = False):
 
 def EdgesToPoints(shape, nr_frac, points_per_edge, twist = 0, twistReverse = False):  
     edges = [] 
-    redges = reorderEdges(shape.Edges, twist, twistReverse)
+    sortedEdges=Part.sortEdges(shape.Edges)[0]
+    redges = reorderEdges(sortedEdges, twist, twistReverse)
     if nr_frac == 1:
         edges = redges
     else:

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -148,7 +148,7 @@ class CurvedSegment:
         
         
     def rescaleRibs(self, fp, ribs):
-        if (fp.makeSurface or fp.makeSolid) and fp.Path is None:
+        if (fp.makeSurface or fp.makeSolid) and fp.Path is None and abs(fp.ActualTwist)<=epsilon:
             start = 1
             end = len(ribs) - 1
             items = fp.Items + 3
@@ -245,7 +245,7 @@ def makeRibsSameShape(fp, items, alongNormal, makeStartEnd = False):
     base1=fp.Shape1.Placement.Base
     base2=fp.Shape2.Placement.Base
     offset=base2-base1
-    if makeStartEnd and (fp.Path is not None):
+    if makeStartEnd and ((fp.Path is not None) or (abs(fp.ActualTwist)>epsilon)):
         start=0
         end=items+2
     else:
@@ -301,7 +301,7 @@ def makeRibsSameShape(fp, items, alongNormal, makeStartEnd = False):
                 ribs.append(Part.makeCompound(curves))
         ribs[-1].Placement.Base=fraction*offset #place the whole rib in the right place instead
             
-    if makeStartEnd and fp.Path is None:
+    if makeStartEnd and fp.Path is None and abs(fp.ActualTwist)<=epsilon:
         ribs.insert(0, fp.Shape1.Shape)
         ribs.append(fp.Shape2.Shape)
         

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -35,7 +35,8 @@ class CurvedSegment:
                  LoftMaxDegree=5,
                  MaxLoftSize=16,
                  ActualTwist=0.0,
-                 Path=None):
+                 Path=None,
+                 ForceInterpolated = False):
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape1",     "CurvedSegment",   "The first object of the segment").Shape1 = shape1
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Shape2",     "CurvedSegment",   "The last object of the segment").Shape2 = shape2
         CurvedShapes.addObjectProperty(fp,"App::PropertyLinkList",  "Hullcurves",   "CurvedSegment",   "Bounding curves").Hullcurves = hullcurves        
@@ -53,6 +54,7 @@ class CurvedSegment:
         CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedSegment",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         CurvedShapes.addObjectProperty(fp,"App::PropertyFloat", "ActualTwist","CurvedSegment",  "Twists the curve by this much.").ActualTwist = ActualTwist
         CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Path",     "CurvedSegment",   "Sweep path").Path = Path
+        CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "ForceInterpolated","CurvedSegment",  "Force Interpolation of sketches").ForceInterpolated = ForceInterpolated
         fp.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         fp.Distribution = Distribution
         self.doScaleXYZ = []
@@ -119,10 +121,13 @@ class CurvedSegment:
             CurvedShapes.addObjectProperty(fp,"App::PropertyFloat", "ActualTwist","CurvedSegment",  "Twists the curve by this much.", init_val=0.0) # backwards compatibility - this upgrades older documents
         if not hasattr(fp, 'Path'):
             CurvedShapes.addObjectProperty(fp,"App::PropertyLink",  "Path",     "CurvedSegment",   "Sweep path", init_val=None) # backwards compatibility - this upgrades older documents
- 
+        if not hasattr(fp, 'ForceInterpolated'):
+            CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "ForceInterpolated","CurvedSegment",  "Force Interpolation of sketches", init_val=False) # backwards compatibility - this upgrades older documents
+
+            
     def makeRibs(self, fp):
         interpolate = False
-        if len(fp.Shape1.Shape.Edges) != len(fp.Shape2.Shape.Edges):
+        if fp.ForceInterpolated or len(fp.Shape1.Shape.Edges) != len(fp.Shape2.Shape.Edges):
             interpolate = True
         else:
             for e in range(0, len(fp.Shape1.Shape.Edges)):

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -389,7 +389,7 @@ def makeRibsInterpolate(fp, items, alongNormal, makeStartEnd = False):
 
 def EdgesToPoints(shape, nr_frac, points_per_edge, twist = 0, twistReverse = False):  
     edges = [] 
-    sortedEdges=Part.sortEdges(shape.Edges)[0]
+    sortedEdges=sum(Part.sortEdges(shape.Edges),[])
     redges = reorderEdges(sortedEdges, twist, twistReverse)
     if nr_frac == 1:
         edges = redges

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -391,10 +391,11 @@ def makeCurvedSegment(Shape1 = None,
                     LoftMaxDegree=5,
                     MaxLoftSize=16,
                     ActualTwist = 0.0,
-                    Path = None):
+                    Path = None,
+                    ForceInterpolated=False):
     import CurvedSegment
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedSegment")
-    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize, ActualTwist, Path)
+    CurvedSegment.CurvedSegment(obj, Shape1, Shape2, Hullcurves, NormalShape1, NormalShape2, Items, Surface, Solid, InterpolationPoints, Twist, TwistReverse, Distribution, DistributionReverse, LoftMaxDegree, MaxLoftSize, ActualTwist, Path, ForceInterpolated)
     if FreeCAD.GuiUp:
         CurvedSegment.CurvedSegmentViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Select two 2D shapes first. The curved segment will be created between them. If 
 - DistributionReverse: Reverses the direction of the Distribution algorithm
 - LoftMaxDegree: degree for surface or solid creation. Play with this parameter if your surface or solid looks distorted
 - MaxLoftSize: Maximum size of a loft segment. The surface is created by creating a loft over many array items, however OpenCascade gets very slow and produces artefacts towards the end of the loft when the array gets too large. Therefore the array gets split up intp sub-arrays of up to MaxLoftSize items. Play with this value if a split between segements ends up in a inconvenient spot. Sensible values are between 10 and 50.
+- ForceInterpolated: By default, CurvedSegment tries a more direct transition from the first to the second object if the objects have the same number of points and lines and interpolates intermediate shapes if they don't. In case the direct approach does not work because the type or order of lines does not match, interpolation can be forced with this parameter even if the number of points is equal. This should only be needed in rare cases.
 
 ### ![CornerShapeIcon](./Resources/icons/CornerShape.svg) Interpolated Middle
 Interpolates a 2D shape into the middle between two 2D curves. The base shapes can be connected to a shape with a sharp corner.


### PR DESCRIPTION
Since the intermediate ribs are turned to bsplines anyway when using the interpolating method, it makes sense to convert the beginning and end shapes `toNurbs()` which turns all edges into bsplines, even if they are not (lines, circles,...)
Bsplines have the advantage that they can be sorted with `Part.sortEdges()` which ensures all edges and all points in both shapes are in the correct order (assuming they are closed shapes) (sadly I only found that method after already implementing the same in CurvedSegment but C++ is faster than python, so sortEdges() is definitely the way to go)

this should drastically reduce the amount of broken curves

additionally a Parameter ForceInterpolated has been introduced to trigger the interpolated method even if the number of points and edges is identical - using that allows a workaround for #49 

this builds on top of all other ongoing pull requests to avoid conflicts. if required I can split that apart.