### PR TITLE
Allow CurvedArray's to use the base shape explicitly...

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -34,7 +34,7 @@ class CurvedArray:
                  Twists = [],
                  LoftMaxDegree=5,
                  MaxLoftSize=16,
-                 KeepBase=False):
+                 KeepBase='None'):
         CurvedShapes.addObjectProperty(obj, "App::PropertyLink",  "Base",     "CurvedArray",   "The object to make an array from").Base = base
         CurvedShapes.addObjectProperty(obj, "App::PropertyLinkList",  "Hullcurves",   "CurvedArray",   "Bounding curves").Hullcurves = hullcurves        
         CurvedShapes.addObjectProperty(obj, "App::PropertyVector", "Axis",    "CurvedArray",   "Direction axis").Axis = axis
@@ -44,7 +44,7 @@ class CurvedArray:
         CurvedShapes.addObjectProperty(obj, "App::PropertyFloat", "OffsetEnd","CurvedArray",  "Offset of the last part from the end in opposite Axis direction").OffsetEnd = OffsetEnd
         CurvedShapes.addObjectProperty(obj, "App::PropertyFloat", "Twist","CurvedArray",  "Rotate around Axis in degrees").Twist = Twist
         CurvedShapes.addObjectProperty(obj, "App::PropertyFloatList","Twists", "CurvedArray","Rotate around Axis in degrees for each item -- overrides Twist").Twists = Twists
-        CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "KeepBase","CurvedArray",  "Include the base shape unmodified").KeepBase = KeepBase
+        CurvedShapes.addObjectProperty(obj, "App::PropertyEnumeration", "KeepBase", "CurvedArray",  "Include the base shape unmodified and where")
         CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "Surface","CurvedArray",  "Make a surface").Surface = Surface
         CurvedShapes.addObjectProperty(obj, "App::PropertyBool", "Solid","CurvedArray",  "Make a solid").Solid = Solid
         CurvedShapes.addObjectProperty(obj, "App::PropertyEnumeration", "Distribution", "CurvedArray",  "Algorithm for distance between elements")
@@ -53,6 +53,8 @@ class CurvedArray:
         CurvedShapes.addObjectProperty(obj,"App::PropertyInteger", "MaxLoftSize", "CurvedArray",   "Max Size of a Loft in Segments.").MaxLoftSize = MaxLoftSize
         obj.Distribution = ['linear', 'parabolic', 'x³', 'sinusoidal', 'asinusoidal', 'elliptic']
         obj.Distribution = Distribution
+        obj.KeepBase = ['None', 'First', 'Last']
+        obj.KeepBase = KeepBase
         self.extract = extract
         self.doScaleXYZ = []
         self.doScaleXYZsum = [False, False, False]
@@ -63,11 +65,6 @@ class CurvedArray:
         ribs = []
         curvebox = FreeCAD.BoundBox(float("-inf"), float("-inf"), float("-inf"), float("inf"), float("inf"), float("inf"))
 
-        startrib = 0
-        if obj.KeepBase:
-            startrib=1
-            ribs.append(obj.Base.Shape)
-            
         for n in range(0, len(obj.Hullcurves)):
             cbbx = obj.Hullcurves[n].Shape.BoundBox
             if self.doScaleXYZ[n][0]:
@@ -103,7 +100,7 @@ class CurvedArray:
         pos0 = startvec + (obj.OffsetStart * obj.Axis)      
             
         if (not hasattr(obj,"Positions") or len(obj.Positions) == 0):
-            for x in range(startrib, sections):
+            for x in range(0, sections):
                 if sections > 1:
                     d = CurvedShapes.distribute(x / (sections - 1), obj.Distribution, obj.DistributionReverse)
                                  
@@ -120,6 +117,10 @@ class CurvedArray:
                 rib = self.makeRibRotate(obj, posvec, x, x / len(obj.Positions), ribs)
                 x = x + 1       
 
+        if (obj.KeepBase == 'First'):
+            ribs[0] = obj.Base.Shape.copy()
+        elif (obj.KeepBase == 'Last'):
+            ribs[-1] = obj.Base.Shape.copy()
         
         if (obj.Surface or obj.Solid) and obj.Items > 1:
             obj.Shape = CurvedShapes.makeSurfaceSolid(ribs, obj.Solid, maxDegree=obj.LoftMaxDegree, maxLoftSize=obj.MaxLoftSize)
@@ -205,7 +206,9 @@ class CurvedArray:
         if not hasattr(fp, 'MaxLoftSize'):
             CurvedShapes.addObjectProperty(fp,"App::PropertyInteger", "MaxLoftSize", "CurvedArray",   "Max Size of a Loft in Segments.", init_val=-1) # backwards compatibility - this upgrades older documents
         if not hasattr(fp, 'KeepBase'):
-            CurvedShapes.addObjectProperty(fp,"App::PropertyBool", "KeepBase", "CurvedArray",   "Include the base shape unmodified", init_val=False) # backwards compatibility - this upgrades older documents
+            CurvedShapes.addObjectProperty(fp, "App::PropertyEnumeration", "KeepBase", "CurvedArray",  "Include the base shape unmodified and where")
+            fp.KeepBase = ['None', 'First', 'Last']
+            fp.KeepBase = 'None'
            
         if "Positions" in prop and len(fp.Positions) != 0:
             setattr(fp,"Items",str(len(fp.Positions)))

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -339,7 +339,7 @@ def makeCurvedArray(Base = None,
                     Twists = [],
                     LoftMaxDegree=5,
                     MaxLoftSize=16,
-                    KeepBase=False):
+                    KeepBase='None'):
     import CurvedArray
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedArray")
     CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree, MaxLoftSize, KeepBase)

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -338,10 +338,11 @@ def makeCurvedArray(Base = None,
                     extract=False,
                     Twists = [],
                     LoftMaxDegree=5,
-                    MaxLoftSize=16):
+                    MaxLoftSize=16,
+                    KeepBase=False):
     import CurvedArray
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurvedArray")
-    CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree, MaxLoftSize)
+    CurvedArray.CurvedArray(obj, Base, Hullcurves, Axis, Items, Position, OffsetStart, OffsetEnd, Twist, Surface, Solid, Distribution, DistributionReverse, False, Twists, LoftMaxDegree, MaxLoftSize, KeepBase)
     if FreeCAD.GuiUp:
         CurvedArray.CurvedArrayViewProvider(obj.ViewObject)
     FreeCAD.ActiveDocument.recompute()


### PR DESCRIPTION
 as part of the array - prevents offset errors and bugs with unions and other booleans

A common usecase for curved shapes is a loft over a series of profiles, for example a wing. While midsections can be done with curved segments, for the end bit, only one profile is available, it then tapers down as defined by hullcurves -- having the final shape defined explicitly with a curvedsegment is very hard.

One would normally want to join all these "parts" of the wing with a boolean - including the final "wingtip"  but this often fails due to a small offset between the base profile of the wingtip and the first "0" rib - even if the hullcurves are a sketch exactly matching the base shape.

This can be solved with this new Property "KeepBase" -- while this not useful in all usecases, for example hullcurves that taper off on multiple sides would not want to use this, for shapes where a defined base shape is key for subsequent boolean operations, this is very important, otherwise the boolean shape fusion often fails or triggers really nasty OCCT errors in FreeCAD

Previously this problem was worked around with the "offset" feature to create small intersecting areas but that hack creates additional problems. Especially with the improvements to boolean operations in freecad 1.1dev - having the shapes match **exactly** is better. At least if a fusion with a matching shape is desired.


