### PR TITLE
fix #34  again

### DIFF
--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -140,7 +140,7 @@ def boundbox_from_intersect(curves, pos, normal, doScaleXYZ, nearestpoints=True)
 
 
 def scaleByBoundbox(shape, boundbox, doScaleXYZ, copy=True):
-    basebbox = shape.BoundBox   
+    basebbox = shape.optimalBoundingBox(False,False)
       
     scalevec = Vector(1, 1, 1)
     if doScaleXYZ[0] and basebbox.XLength > epsilon: scalevec.x = boundbox.XLength / basebbox.XLength


### PR DESCRIPTION
fix #34 

shape.BoundBox has incorrect values in CurvedSegments, since the `shape` has been newly generated but not been displayed yet (not tessellated)  instead of tesselating the shape, we call optimalBoundingBox which computes the dimensions without relying on Tessellation

this should ideally be done everywhere in the code, but optimalBoundingBox has slightly different return than BoundBox does which causes issues with some operations (nearly one-dimensional ribs, etc...) since even flat shapes can up to 2*epsilon thickness reported depending on OCCT version

in this place it is absolutely needed because otherwise curvedsegments are badly broken