### PR TITLE
Tessellation independence

### DIFF
--- a/CurvedArray.py
+++ b/CurvedArray.py
@@ -66,7 +66,7 @@ class CurvedArray:
         curvebox = FreeCAD.BoundBox(float("-inf"), float("-inf"), float("-inf"), float("inf"), float("inf"), float("inf"))
 
         for n in range(0, len(obj.Hullcurves)):
-            cbbx = obj.Hullcurves[n].Shape.BoundBox
+            cbbx = obj.Hullcurves[n].Shape.optimalBoundingBox(False,False)
             if self.doScaleXYZ[n][0]:
                 if cbbx.XMin > curvebox.XMin: curvebox.XMin = cbbx.XMin
                 if cbbx.XMax < curvebox.XMax: curvebox.XMax = cbbx.XMax
@@ -76,19 +76,20 @@ class CurvedArray:
             if self.doScaleXYZ[n][2]:
                 if cbbx.ZMin > curvebox.ZMin: curvebox.ZMin = cbbx.ZMin
                 if cbbx.ZMax < curvebox.ZMax: curvebox.ZMax = cbbx.ZMax
-            
+           
+        h0bbox = obj.Hullcurves[0].Shape.optimalBoundingBox(False,False)
         if curvebox.XMin == float("-inf"): 
-            curvebox.XMin = obj.Hullcurves[0].Shape.BoundBox.XMin
+            curvebox.XMin = h0bbox.XMin
         if curvebox.XMax == float("inf"): 
-            curvebox.XMax = obj.Hullcurves[0].Shape.BoundBox.XMax
+            curvebox.XMax = h0bbox.XMax
         if curvebox.YMin == float("-inf"): 
-            curvebox.YMin = obj.Hullcurves[0].Shape.BoundBox.YMin
+            curvebox.YMin = h0bbox.YMin
         if curvebox.YMax == float("inf"): 
-            curvebox.YMax = obj.Hullcurves[0].Shape.BoundBox.YMax
+            curvebox.YMax = h0bbox.YMax
         if curvebox.ZMin == float("-inf"): 
-            curvebox.ZMin = obj.Hullcurves[0].Shape.BoundBox.ZMin
+            curvebox.ZMin = h0bbox.ZMin
         if curvebox.ZMax == float("inf"): 
-            curvebox.ZMax = obj.Hullcurves[0].Shape.BoundBox.ZMax
+            curvebox.ZMax = h0bbox.ZMax
          
         areavec = Vector(curvebox.XLength, curvebox.YLength, curvebox.ZLength)
         deltavec = areavec.scale(obj.Axis.x, obj.Axis.y ,obj.Axis.z) - (obj.OffsetStart + obj.OffsetEnd) * obj.Axis
@@ -137,10 +138,11 @@ class CurvedArray:
     def makeRibRotate(self, obj, posvec, x, d, ribs):
         dolly = self.makeRib(obj, posvec)
         if dolly:
+            dbbox = dolly.optimalBoundingBox(False,False)
             if x < len(obj.Twists):
-                dolly = dolly.rotate(dolly.BoundBox.Center, obj.Axis, obj.Twists[x])
+                dolly = dolly.rotate(dbbox.Center, obj.Axis, obj.Twists[x])
             elif not obj.Twist == 0:
-                dolly = dolly.rotate(dolly.BoundBox.Center, obj.Axis, obj.Twist * d)        
+                dolly = dolly.rotate(dbbox.Center, obj.Axis, obj.Twist * d)        
         
             ribs.append(dolly)            
         
@@ -167,7 +169,7 @@ class CurvedArray:
         self.doScaleXYZsum = [False, False, False]
         sumbbox=None   #Define the variable other wise it causes error 
         for h in prop.Hullcurves:
-            bbox = h.Shape.BoundBox
+            bbox = h.Shape.optimalBoundingBox(False,False)
             if h == prop.Hullcurves[0]:
                 sumbbox = bbox
             else:

--- a/CurvedPathArray.py
+++ b/CurvedPathArray.py
@@ -63,7 +63,7 @@ class CurvedPathArray:
         curvebox = FreeCAD.BoundBox(float("-inf"), float("-inf"), float("-inf"), float("inf"), float("inf"), float("inf"))
            
         for n in range(0, len(obj.Hullcurves)):
-            cbbx = obj.Hullcurves[n].Shape.BoundBox
+            cbbx = obj.Hullcurves[n].Shape.optimalBoundingBox(False,False)
             if self.doScaleXYZ[n][0]:
                 if cbbx.XMin > curvebox.XMin: curvebox.XMin = cbbx.XMin
                 if cbbx.XMax < curvebox.XMax: curvebox.XMax = cbbx.XMax
@@ -75,18 +75,19 @@ class CurvedPathArray:
                 if cbbx.ZMax < curvebox.ZMax: curvebox.ZMax = cbbx.ZMax
         
         if len(obj.Hullcurves) > 0: 
+            h0bbox = obj.Hullcurves[0].Shape.optimalBoundingBox(False,False)
             if curvebox.XMin == float("-inf"): 
-                curvebox.XMin = obj.Hullcurves[0].Shape.BoundBox.XMin
+                curvebox.XMin = h0bbox.XMin
             if curvebox.XMax == float("inf"): 
-                curvebox.XMax = obj.Hullcurves[0].Shape.BoundBox.XMax
+                curvebox.XMax = h0bbox.XMax
             if curvebox.YMin == float("-inf"): 
-                curvebox.YMin = obj.Hullcurves[0].Shape.BoundBox.YMin
+                curvebox.YMin = h0bbox.YMin
             if curvebox.YMax == float("inf"): 
-                curvebox.YMax = obj.Hullcurves[0].Shape.BoundBox.YMax
+                curvebox.YMax = h0bbox.YMax
             if curvebox.ZMin == float("-inf"): 
-                curvebox.ZMin = obj.Hullcurves[0].Shape.BoundBox.ZMin
+                curvebox.ZMin = h0bbox.ZMin
             if curvebox.ZMax == float("inf"): 
-                curvebox.ZMax = obj.Hullcurves[0].Shape.BoundBox.ZMax
+                curvebox.ZMax = h0bbox.ZMax
          
         maxlen = 0   
         edgelen = []
@@ -114,7 +115,7 @@ class CurvedPathArray:
                     #dolly = self.makeRib(obj, posvec, direction)
                     dolly = obj.Base.Shape.copy()
                     if rotaxis.Length > epsilon:
-                        dolly = dolly.rotate(dolly.BoundBox.Center, rotaxis, angle)
+                        dolly = dolly.rotate(dolly.optimalBoundingBox(False,False).Center, rotaxis, angle)
 
                     dolly.Placement.Base = posvec
                     if dolly: 
@@ -152,7 +153,7 @@ class CurvedPathArray:
         self.doScaleXYZsum = [False, False, False]
         bbox = None
         for h in prop.Hullcurves:
-            bbox = h.Shape.BoundBox
+            bbox = h.Shape.optimalBoundingBox(False,False)
             doScale = [False, False, False]
             
             if bbox.XLength > epsilon: 
@@ -168,7 +169,7 @@ class CurvedPathArray:
             
         if bbox:    
             for h in prop.Hullcurves:
-                bbox.add(h.Shape.BoundBox)
+                bbox.add(h.Shape.optimalBoundingBox(False,False))
                       
             if bbox.XLength > epsilon: 
                 self.doScaleXYZsum[0] = prop.ScaleX

--- a/CurvedSegment.py
+++ b/CurvedSegment.py
@@ -85,7 +85,7 @@ class CurvedSegment:
             self.doScaleXYZ = []
             self.doScaleXYZsum = [False, False, False]
             for h in fp.Hullcurves:
-                bbox = h.Shape.BoundBox
+                bbox = h.Shape.optimalBoundingBox(False,False)
                 doScale = [False, False, False]
                 
                 if bbox.XLength > epsilon: 
@@ -174,7 +174,7 @@ class CurvedSegment:
         for i in range(start, end):
             d = CurvedShapes.distribute(i / items, fp.Distribution, fp.DistributionReverse)
             normal = CurvedShapes.vectorMiddle(fp.NormalShape1, fp.NormalShape2, d)
-            #Draft.makeLine(ribs[i].BoundBox.Center, ribs[i].BoundBox.Center + normal)
+            #Draft.makeLine(ribs[i].optimalBoundingBox(False,False).Center, ribs[i].optimalBoundingBox(False,False).Center + normal)
             ribs[i] = ribs[i].rotate(bc0+d*(bc1-bc0), normal, fp.Twist * d)
             direction = normal
             if maxlen>0:
@@ -193,7 +193,7 @@ class CurvedSegment:
                         ribs[i].Placement.Base = posvec
 
             if len(fp.Hullcurves) > 0:
-                bbox = CurvedShapes.boundbox_from_intersect(fp.Hullcurves, ribs[i].BoundBox.Center, direction, self.doScaleXYZ)
+                bbox = CurvedShapes.boundbox_from_intersect(fp.Hullcurves, ribs[i].optimalBoundingBox(False,False).Center, direction, self.doScaleXYZ)
                 if bbox:              
                     ribs[i] = CurvedShapes.scaleByBoundbox(ribs[i], bbox, self.doScaleXYZsum, copy=False)
 
@@ -235,7 +235,7 @@ def vectorMiddlePlaneNormal(vec1, vec2, fraction, normalShape1, normalShape2):
 
 
 def getMidPlane(fp, fraction):
-    midvec = CurvedShapes.vectorMiddle(fp.Shape1.Shape.BoundBox.Center, fp.Shape2.Shape.BoundBox.Center, fraction)
+    midvec = CurvedShapes.vectorMiddle(fp.Shape1.Shape.optimalBoundingBox(False,False).Center, fp.Shape2.Shape.optimalBoundingBox(False,False).Center, fraction)
     midnorm = CurvedShapes.vectorMiddle(fp.NormalShape1, fp.NormalShape2, fraction)
     return Part.Plane(midvec, midnorm)
         

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -6,7 +6,7 @@ import Part
 import math
 import CompoundTools.Explode
 
-epsilon = 1e-7
+epsilon = 1e-6
 
 
 def addObjectProperty(obj, ptype, pname, *args, init_val=None):

--- a/CurvedShapes.py
+++ b/CurvedShapes.py
@@ -140,7 +140,7 @@ def boundbox_from_intersect(curves, pos, normal, doScaleXYZ, nearestpoints=True)
 
 
 def scaleByBoundbox(shape, boundbox, doScaleXYZ, copy=True):
-    basebbox = shape.BoundBox   
+    basebbox = shape.optimalBoundingBox(False,False)
       
     scalevec = Vector(1, 1, 1)
     if doScaleXYZ[0] and basebbox.XLength > epsilon: scalevec.x = boundbox.XLength / basebbox.XLength
@@ -283,7 +283,7 @@ def getNormal(obj):
     if hasattr(obj, 'Dir'):
         return obj.Dir
     else:
-        bbox = obj.Shape.BoundBox
+        bbox = obj.Shape.optimalBoundingBox(False,False)
         if bbox.XLength < epsilon: return Vector(1.0,0.0,0.0)
         elif bbox.YLength < epsilon: return Vector(0.0,1.0,0.0)
         elif bbox.ZLength < epsilon: return Vector(0.0,0.0,1.0)

--- a/FlyingWingS800.py
+++ b/FlyingWingS800.py
@@ -186,7 +186,7 @@ def draw_S800():
     
     doc.recompute()
     axis=cutpathPoints[1].sub(cutpathPoints[0])
-    center = ElevonLeft.Placement.Base.add(Vector(midWidth/2, midLength, ElevonLeft.Shape.BoundBox.ZMax))
+    center = ElevonLeft.Placement.Base.add(Vector(midWidth/2, midLength, ElevonLeft.Shape.optimalBoundingBox(False,False).ZMax))
     Draft.rotate([ElevonLeft], ElevonLeftAngle, center, axis=axis, copy=False)
     Draft.rotate([ElevonRight1], ElevonRightAngle, center, axis=axis, copy=False)
     

--- a/Horten_HIX.py
+++ b/Horten_HIX.py
@@ -176,7 +176,7 @@ def draw_HortenHIX():
     Wing.Tool = TurbineCut
     doc.recompute()
     
-    ymax = WingSurface.Shape.BoundBox.YMin + WingSurface.Shape.BoundBox.YLength
+    ymax = WingSurface.Shape.optimalBoundingBox(False,False).YMin + WingSurface.Shape.optimalBoundingBox(False,False).YLength
     rota = FreeCAD.Rotation(Vector(0,0,1), 28)
     vecToWingEnd28 = rota.multVec(Vector(0,1,0))
     WingCutFront = CurvedShapes.cutSurfaces([Wing], Normal = vecToWingEnd28, Position=Vector(0, ymax * 0.85, 0), Face=False, Simplify=0)

--- a/NotchConnector.py
+++ b/NotchConnector.py
@@ -44,8 +44,8 @@ class NotchConnector:
         
         fp.Proxy = None
         if fp.CutDirection == Vector(0.0,0.0,0.0):
-            bbox1 = self.extractCompounds([fp.Base])[0].Shape.BoundBox
-            bbox2 = self.extractCompounds(fp.Tools)[0].Shape.BoundBox
+            bbox1 = self.extractCompounds([fp.Base])[0].Shape.optimalBoundingBox(False,False)
+            bbox2 = self.extractCompounds(fp.Tools)[0].Shape.optimalBoundingBox(False,False)
             v = Vector(1,1,1)
             
             if abs(bbox1.XLength - bbox2.XLength) > epsilon:
@@ -115,11 +115,11 @@ class NotchConnector:
                 
                 for tool in self.extractShapes(fp.Tools):  
                     if fp.ShiftLength == 0:  
-                        tbox = tool.optimalBoundingBox()
+                        tbox = tool.optimalBoundingBox(False,False)
                         common = tool.common(bShape)
-                        cbox = common.BoundBox
+                        cbox = common.optimalBoundingBox(False,False)
                         if cbox.XLength + cbox.YLength + cbox.ZLength > epsilon:
-                            cbox = common.optimalBoundingBox()
+                            cbox = common.optimalBoundingBox(False,False)
                             vSize = Vector(cbox.XLength, cbox.YLength, cbox.ZLength)
                             vPlace = Vector(cbox.XMin, cbox.YMin, cbox.ZMin)
                             if vSize.x < epsilon or vSize.x > tbox.XLength: 

--- a/SurfaceCut.py
+++ b/SurfaceCut.py
@@ -53,10 +53,11 @@ class SurfaceCut:
         else:
             bbox = None
             for obj in fp.Surfaces:
+                obbox = obj.Shape.optimalBoundingBox(False,False)
                 if not bbox:
-                    bbox = obj.Shape.BoundBox
+                    bbox = obbox
                 else:
-                    bbox = bbox.united(obj.Shape.BoundBox)
+                    bbox = bbox.united(obbox)
                 
             vOffset = Vector(bbox.XMin, bbox.YMin, bbox.ZMin)
             


### PR DESCRIPTION
Shape.BoundBox depends on the Shapes tessellation.

The tessellation has 2 properties

1. It only exists if the shape has been tessellated in the first place (if not, the valus can be very wrong, for example if the file is being edited in FreeCADCmd without GUI, parts are not tessellated at all and BoundBox can be off by up to 50% in any dimension in case of curved shapes)
2. IF the part is tessellated, the exact dimensions depend on the Tessellation accuracy, which in turn depends on 
`Preferences->Part->Shape_view->Maximum deviation`
and
`Preferences->Part->Shape_view->Maximum angualar deviation`

The effect of this is that the users GUI settings for display-accuracy (and freecad rendering speed) affect the exact dimensions of the bounding boxes computed by CurvedShapes - and that in turn can lead to errors in the shape -- > i.e. parts that work fine on one users computer generate Geometry errors and fail in subsequent boolean operations on another users computer because they have the display accuracy set lower for performance reasons.

This is technically a flaw in FreeCAD itself -- Shape.BoundBox is a property that should NOT be calculated based on tessellation. There is an existing bug report for this:

https://github.com/FreeCAD/FreeCAD/issues/17340

however CurvedShapes is affected by this to a much larger dergree, since it uses BoundBox everywhere.

fix #52



Note: this is a draft. Right now the "fix" has too many side effects. Using "optimalBoundingBox()" is more tricky than BoundBox because of several issues:

1. the default call to optrimalBoundBox is optimalBoundBox(True,False) - which uses a triangualted approximation - this yields to flat 2d shapes having a bounding box that can be several millimeters thick for some reason
2. Even if optimalBoundBox is called explicitly with optimalBoundBox(False,False) I have seen "thickness" of 2d parts of 2 times epsilon (2e-7) 

even with "epsion" increased to 1e-6 some curvedarrays end up weird with broken 1.dimensional ribs created at the beginning or the end sometimes.  so a lot more "sanitation" needs to be done with optimalBoundingBox than with BoundBox


Also: on 0.21.2 with OCCT 7.3.0 a call to Shape.optimalBoundBox(False,False) on a standard Part Cube caused FreeCAD to segfault. on 1.0RC4 with OCCT with 7.6.3 there is no segfault
