### PR TITLE
Update package.xml with correct icon location

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <license file="LICENSE">LGPL-2.1</license>
   <url type="repository" branch="master">https://github.com/chbergmann/CurvedShapesWorkbench</url>
   <url type="documentation">https://github.com/chbergmann/CurvedShapesWorkbench/README.md</url>
-  <icon>Resources/icon/curvedArray.svg</icon>
+  <icon>Resources/icons/curvedArray.svg</icon>
 
   <content>
     <workbench>


### PR DESCRIPTION
Unfortunately this incorrect location is causing an unnecessary warning in AddonManager:

`Request failed: PySide2.QtNetwork.QNetworkReply.NetworkError.ContentNotFoundError`